### PR TITLE
Update NameProvider.lua

### DIFF
--- a/req/NameProvider.lua
+++ b/req/NameProvider.lua
@@ -50,7 +50,7 @@ function NameProvider:_create_name_entry_from_tweak_data_id(tweak)
   if not tweak then
     return
   end
-  local name = tweak:gsub("_female", ""):pretty(true):gsub("Swat", "SWAT"):gsub("Fbi", "FBI")
+  local name = tweak:gsub("_female", ""):pretty(true):gsub("_r870", "Shotgunner"):gsub("Swat", "SWAT"):gsub("Fbi", "FBI")
   self._names[tweak] = { [self._current_level_id] = name }
   return name
 end


### PR DESCRIPTION
"_r870" tag lets people know that the enemy is a boomstick guy.

Since the heavy GenSec Elites and ZEAL units are an impossibility, I guess this will have to do... I hope.