### PR TITLE
Attempt to fix the FBI Heavy GenSecs

### DIFF
--- a/req/NameProvider.lua
+++ b/req/NameProvider.lua
@@ -22,6 +22,7 @@ function NameProvider:_init_names()
     drug_lord_boss = { default = "Ernesto Sosa" },
     old_hoxton_mission = { default = "Hoxton" },
     spa_vip = { default = "Charon" },
+    locke = { default = "Vernon Locke", wwh = "Mr. Blonde" },
     phalanx_vip = { default = "Neville Winters" },
     phalanx_minion = { default = "Phalanx Shield" },
     bank_manager = { default = "Bank Manager", dah = "Ralph Garnet" },
@@ -50,7 +51,7 @@ function NameProvider:_create_name_entry_from_tweak_data_id(tweak)
   if not tweak then
     return
   end
-  local name = tweak:gsub("_female", ""):pretty(true):gsub("Swat", "SWAT"):gsub("Fbi", "FBI")
+  local name = tweak:gsub("_female", ""):pretty(true):gsub("_swat", "SWAT"):gsub("fbi_heavy", "MFR")
   self._names[tweak] = { [self._current_level_id] = name }
   return name
 end


### PR DESCRIPTION
Mr. Blonde in the Reservoir Dogs Heist is a clone of Locke, like Lucina is a moveset clone of Marth in Smash Bros. 4, and this is my proposed attempt at fixing the Heavy GenSec SWATs being called FBI Heavies.

…I guess it *would* be possible to make the MFR units have proper names if we do it smart when differenting the different enemy units; 
	self:_init_fbi(presets)
	self:_init_swat(presets)
	self:_init_heavy_swat(presets)
	self:_init_fbi_swat(presets)
	self:_init_fbi_heavy_swat(presets)
	self:_init_city_swat(presets)


However!!! How does one do this for Akan's mercenaries?