### PR TITLE
FBI Heavy SWAT to MFR Unit

### DIFF
--- a/loc/english.txt
+++ b/loc/english.txt
@@ -1,4 +1,5 @@
 {
+  "unit_name_fbi_heavy_swat" : "MFR Unit",
   "unit_name_spooc" : "Cloaker",
   "unit_name_tank_green" : "Bulldozer",
   "unit_name_tank_black" : "Blackdozer",


### PR DESCRIPTION
Because, when these guys spawn on Mayhem & Death Wish with the GenSec City Elite, they are still identified as being with the FBI. The most likely reason for this is that back when the Death Wish update hit, the MFRs didn't have a GenSec counterpart. Patches later they finally got one.